### PR TITLE
Token validation and Error Page with global context added

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1312,6 +1312,18 @@
         "@babel/runtime": "^7.4.4"
       }
     },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.47",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.47.tgz",
+      "integrity": "sha512-+WC3O0M/769D3nO9Rqupusc+lob7tQMe5/DnOjAhZ0bpXlJbhZb7N84WkEk4JgQLj6ydP8e9Jhqd1lG+mGj+xw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.9.6",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
+      }
+    },
     "@material-ui/styles": {
       "version": "4.9.6",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.9.6.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.47",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",

--- a/src/App.js
+++ b/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Route, Redirect } from 'react-router';
 import { BrowserRouter, Switch } from 'react-router-dom';
 import MainPage from './pages/MainPage/MainPage';
@@ -6,14 +6,17 @@ import LoginPage from './pages/LoginPage/LoginPage';
 import RegistrationPage from './pages/RegistrationPage/RegistrationPage';
 import ProfilePage from './pages/ProfilePage/ProfilePage';
 import ErrorPage from './pages/ErrorPage/ErrorPage';
+import { ErrorsContext } from './context/ErrorsContext';
 import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 
 const theme = createMuiTheme();
 
-class App extends React.Component {
+export default function App() {
 
-  render() {
-    return (
+  const [errors, setErrors] = useState({});
+
+  return (
+    <ErrorsContext.Provider value={[errors, setErrors]}>
       <MuiThemeProvider theme={theme}>
         <BrowserRouter>
           <Switch>
@@ -26,8 +29,6 @@ class App extends React.Component {
           </Switch>
         </BrowserRouter>
       </MuiThemeProvider>
-    );
-  }
+    </ErrorsContext.Provider>
+  );
 }
-
-export default withStore(App, initialState);

--- a/src/App.js
+++ b/src/App.js
@@ -5,7 +5,8 @@ import MainPage from './pages/MainPage/MainPage';
 import LoginPage from './pages/LoginPage/LoginPage';
 import RegistrationPage from './pages/RegistrationPage/RegistrationPage';
 import ProfilePage from './pages/ProfilePage/ProfilePage';
-import { MuiThemeProvider, createMuiTheme, makeStyles } from '@material-ui/core/styles';
+import ErrorPage from './pages/ErrorPage/ErrorPage';
+import { MuiThemeProvider, createMuiTheme } from '@material-ui/core/styles';
 
 const theme = createMuiTheme();
 
@@ -20,6 +21,7 @@ class App extends React.Component {
             <Route path='/login' component={LoginPage} />
             <Route path='/registration/:token' component={RegistrationPage} />
             <Route path='/profile' component={ProfilePage} />
+            <Route path='/error' component={ErrorPage} />
             <Redirect to='/' />
           </Switch>
         </BrowserRouter>
@@ -28,4 +30,4 @@ class App extends React.Component {
   }
 }
 
-export default App;
+export default withStore(App, initialState);

--- a/src/context/ErrorsContext.js
+++ b/src/context/ErrorsContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const ErrorsContext = createContext({errors: [] });

--- a/src/helpers/registrationHelpers.js
+++ b/src/helpers/registrationHelpers.js
@@ -3,7 +3,12 @@ export const getEmailFromToken = async (token) => {
     // Implement server-side fetching of the email
     return new Promise((resolve, reject) => {
         setTimeout(() => {
-            resolve({value: "test@email.com"});
+            if (token === 'test') {
+                resolve({value: 'test@email.com', errors: null});
+            } else {
+                resolve({errors: ['Such registration page does not exist...']});
+            }
+            
         }, 500)
     })
 }

--- a/src/pages/ErrorPage/ErrorPage.js
+++ b/src/pages/ErrorPage/ErrorPage.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import { useStore } from 'react-context-hook';
+
+function ErrorPage() {
+
+    const [errors, setErrors, deleteErrors] = useStore('errors');
+
+    console.log(errors);
+
+    return (
+        <div>
+            {errors}
+        </div>
+    );
+}
+
+export default ErrorPage;

--- a/src/pages/ErrorPage/ErrorPage.js
+++ b/src/pages/ErrorPage/ErrorPage.js
@@ -1,16 +1,20 @@
-import React from 'react';
-import { useStore } from 'react-context-hook';
+import React, { useContext } from 'react';
+import { ErrorsContext } from '../../context/ErrorsContext';
+import { Alert, AlertTitle } from '@material-ui/lab';
 
 function ErrorPage() {
 
-    const [errors, setErrors, deleteErrors] = useStore('errors');
-
-    console.log(errors);
+    const [errors, setErrors] = useContext(ErrorsContext);
 
     return (
         <div>
-            {errors}
-        </div>
+            {errors.errors ? errors.errors.map(element => (
+                <Alert severity="error">
+                    <AlertTitle>Error</AlertTitle>
+                    {element}
+                </Alert>
+            )) : ''}
+        </div >
     );
 }
 

--- a/src/pages/RegistrationPage/RegistrationPage.js
+++ b/src/pages/RegistrationPage/RegistrationPage.js
@@ -39,7 +39,7 @@ const useStyles = makeStyles(theme => ({
 
 function RegistrationPage() {
 
-  const [email, setEmail] = useState('');
+  const [email, setEmail] = useState({ value: null, isLocked: false });
   const [firstName, setFirstName] = useState({ value: null, error: false, helperText: null });
   const [lastName, setLastName] = useState({ value: null, error: false, helperText: null });
   const [password, setPassword] = useState({ value: null, error: false, helperText: null });
@@ -47,6 +47,14 @@ function RegistrationPage() {
   const params = useParams();
   const history = useHistory();
   const classes = useStyles();
+
+  useEffect(() => {
+    async function getEmail(token) {
+      const response = await getEmailFromToken(token);
+      setEmail({ value: response.value, isLocked: true });
+    }
+    getEmail(params.token);
+  }, [])
 
   const register = e => {
     // TO DO
@@ -68,11 +76,12 @@ function RegistrationPage() {
                 <AccountBox fontSize="large" />
               </Avatar>
               <TextField
+                value={email.value}
                 className={classes.textField}
-                defaultValue={email}
-                
+                InputProps={{
+                  readOnly: email.isLocked,
+                }}
                 fullWidth
-                autoFocus
                 required
               />
               <TextField

--- a/src/pages/RegistrationPage/RegistrationPage.js
+++ b/src/pages/RegistrationPage/RegistrationPage.js
@@ -10,7 +10,7 @@ import Avatar from '@material-ui/core/Avatar';
 import AccountBox from '@material-ui/icons/AccountBox';
 import { makeStyles } from '@material-ui/core/styles';
 import * as constants from '../../constants/RegistrationPage.constants.js';
-import { useHistory, useParams } from 'react-router-dom';
+import { useHistory, useParams, Redirect } from 'react-router-dom';
 import { getEmailFromToken } from '../../helpers/registrationHelpers';
 
 
@@ -44,6 +44,7 @@ function RegistrationPage() {
   const [lastName, setLastName] = useState({ value: null, error: false, helperText: null });
   const [password, setPassword] = useState({ value: null, error: false, helperText: null });
   const [repeatPassword, setRepeatPassword] = useState({ value: null, error: false, helperText: null });
+  const [redirect, setRedirect] = useState({ shouldRedirect: false, route: ''});
   const params = useParams();
   const history = useHistory();
   const classes = useStyles();
@@ -51,6 +52,9 @@ function RegistrationPage() {
   useEffect(() => {
     async function getEmail(token) {
       const response = await getEmailFromToken(token);
+      if (response.errors) {
+        setRedirect({shouldRedirect: true, route: '/error'});
+      }
       setEmail({ value: response.value, isLocked: true });
     }
     getEmail(params.token);
@@ -60,11 +64,12 @@ function RegistrationPage() {
     // TO DO
     // implement field validation
     e.preventDefault();
-    history.push("/");
+    setRedirect({shouldRedirect: true, route: '/'});
   }
 
   return (
     <div>
+      {redirect.shouldRedirect ? <Redirect to={redirect.route}/> : null}
       <Container maxWidth="xs">
         <Grid container item justify="center">
           <Card className={classes.card}>
@@ -76,7 +81,7 @@ function RegistrationPage() {
                 <AccountBox fontSize="large" />
               </Avatar>
               <TextField
-                value={email.value}
+                value={email.value || ''}
                 className={classes.textField}
                 InputProps={{
                   readOnly: email.isLocked,

--- a/src/pages/RegistrationPage/RegistrationPage.js
+++ b/src/pages/RegistrationPage/RegistrationPage.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import './RegistrationPage.scss';
 import TextField from '@material-ui/core/TextField';
 import Grid from '@material-ui/core/Grid';
@@ -12,6 +12,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import * as constants from '../../constants/RegistrationPage.constants.js';
 import { useHistory, useParams, Redirect } from 'react-router-dom';
 import { getEmailFromToken } from '../../helpers/registrationHelpers';
+import { ErrorsContext } from '../../context/ErrorsContext';
 
 
 const useStyles = makeStyles(theme => ({
@@ -45,6 +46,7 @@ function RegistrationPage() {
   const [password, setPassword] = useState({ value: null, error: false, helperText: null });
   const [repeatPassword, setRepeatPassword] = useState({ value: null, error: false, helperText: null });
   const [redirect, setRedirect] = useState({ shouldRedirect: false, route: ''});
+  const [errors, setErrors] = useContext(ErrorsContext);
   const params = useParams();
   const history = useHistory();
   const classes = useStyles();
@@ -53,6 +55,7 @@ function RegistrationPage() {
     async function getEmail(token) {
       const response = await getEmailFromToken(token);
       if (response.errors) {
+        setErrors({ errors: response.errors });
         setRedirect({shouldRedirect: true, route: '/error'});
       }
       setEmail({ value: response.value, isLocked: true });


### PR DESCRIPTION
I've added a basis for the token validation logic and the Error page to be redirected to in case the token is invalid. Also, introduced global context for getting and setting the errors, could be used for other global contexts in the future (do review if it's the right approach for this).