### PR TITLE
Learning day improvements and functionality for comments

### DIFF
--- a/src/components/GoalsList/GoalsList.js
+++ b/src/components/GoalsList/GoalsList.js
@@ -77,7 +77,7 @@ const GoalsList = ({ setLoading, setAlert, topics, isTeamCalendar }) => {
             <Grid item xs={12}>
                 {newGoalCard ? <NewGoalCard topics={topics} setNewGoalCard={setNewGoalCard} addGoal={addGoal} topic={topic} setTopic={setTopic} /> : ''}
                 {
-                    goals.map(goal =>
+                    goals.sort((goal1, goal2) => new Date(goal1.lastUpdated).getTime() > new Date(goal2.lastUpdated).getTime() ? -1 : 1).map(goal =>
                         <GoalCard goal={goal} updateGoal={updateGoal} />
                     )
                 }

--- a/src/components/LearningDaysList/LearningDay/Comments/Comments.js
+++ b/src/components/LearningDaysList/LearningDay/Comments/Comments.js
@@ -1,18 +1,29 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Grid from '@material-ui/core/Grid';
 import TextField from '@material-ui/core/TextField';
 import Paper from '@material-ui/core/Paper';
 import AddCommentIcon from '@material-ui/icons/AddComment';
 import IconButton from '@material-ui/core/IconButton';
 import LinearProgress from '@material-ui/core/LinearProgress';
+import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import Button from '@material-ui/core/Button';
+import CardHeader from '@material-ui/core/CardHeader';
+import Avatar from '@material-ui/core/Avatar';
 
 import { useStyles } from './Comments.styles';
 
-const Comments = ({ commentsLoading, addComment }) => {
+const Comments = ({ commentsLoading, addComment, getComments, comments }) => {
 
     const [comment, setComment] = useState('');
 
     const classes = useStyles();
+
+    useEffect(() => {
+        getComments();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 
     const handleAddCommentClick = (e) => {
         addComment(comment);
@@ -29,22 +40,23 @@ const Comments = ({ commentsLoading, addComment }) => {
             </Grid>
             <Grid item xs className={classes.commentsList}>
                 {commentsLoading ? <LinearProgress /> : ''}
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
-                <Paper className={classes.paper}>Comment</Paper>
+                {comments.sort((comment1, comment2) => new Date(comment1.date).getTime() > new Date(comment2.date).getTime() ? 1 : -1).map(comment => (
+                    <Card className={classes.card}>
+                        <CardHeader
+                            avatar={
+                                <Avatar aria-label="learning-day" className={classes.avatar}>
+                                    {comment.userId}
+                                </Avatar>
+                            }
+                            title={comment.userId}
+                            subheader={new Date(comment.date).toDateString()}
+
+                        />
+                        <CardContent>
+                            {comment.comment}
+                        </CardContent>
+                    </Card>
+                ))}
             </Grid>
         </Grid>
     )

--- a/src/components/LearningDaysList/LearningDay/Comments/Comments.js
+++ b/src/components/LearningDaysList/LearningDay/Comments/Comments.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import Grid from '@material-ui/core/Grid';
+import TextField from '@material-ui/core/TextField';
+import Paper from '@material-ui/core/Paper';
+import AddCommentIcon from '@material-ui/icons/AddComment';
+import IconButton from '@material-ui/core/IconButton';
+import LinearProgress from '@material-ui/core/LinearProgress';
+
+import { useStyles } from './Comments.styles';
+
+const Comments = ({ commentsLoading, addComment }) => {
+
+    const [comment, setComment] = useState('');
+
+    const classes = useStyles();
+
+    const handleAddCommentClick = (e) => {
+        addComment(comment);
+    }
+
+    return (
+        <Grid container spacing={1} direction="column-reverse" alignItems="stretch" justify="space-between" className={classes.container}>
+            <Grid item>
+                <TextField multiline label="Comment" variant="outlined" rows={3} className={classes.commentField} value={comment}
+                    onChange={e => setComment(e.target.value)} />
+                <IconButton className={classes.commentButton} onClick={(e) => handleAddCommentClick(e)} disabled={!comment}>
+                    <AddCommentIcon></AddCommentIcon>
+                </IconButton>
+            </Grid>
+            <Grid item xs className={classes.commentsList}>
+                {commentsLoading ? <LinearProgress /> : ''}
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+                <Paper className={classes.paper}>Comment</Paper>
+            </Grid>
+        </Grid>
+    )
+}
+
+export default Comments;

--- a/src/components/LearningDaysList/LearningDay/Comments/Comments.js
+++ b/src/components/LearningDaysList/LearningDay/Comments/Comments.js
@@ -1,21 +1,21 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import Grid from '@material-ui/core/Grid';
+import { UserContext } from '../../../../context/UserContext';
 import TextField from '@material-ui/core/TextField';
-import Paper from '@material-ui/core/Paper';
 import AddCommentIcon from '@material-ui/icons/AddComment';
+import DeleteIcon from '@material-ui/icons/Delete';
 import IconButton from '@material-ui/core/IconButton';
 import LinearProgress from '@material-ui/core/LinearProgress';
 import Card from '@material-ui/core/Card';
-import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
-import Button from '@material-ui/core/Button';
 import CardHeader from '@material-ui/core/CardHeader';
 import Avatar from '@material-ui/core/Avatar';
 
 import { useStyles } from './Comments.styles';
 
-const Comments = ({ commentsLoading, addComment, getComments, comments }) => {
+const Comments = ({ commentsLoading, addComment, getComments, deleteComment, comments }) => {
 
+    const [user] = useContext(UserContext);
     const [comment, setComment] = useState('');
 
     const classes = useStyles();
@@ -27,6 +27,10 @@ const Comments = ({ commentsLoading, addComment, getComments, comments }) => {
 
     const handleAddCommentClick = (e) => {
         addComment(comment);
+    }
+
+    const handleDeleteCommentClick = (e, commentId) => {
+        deleteComment(commentId);
     }
 
     return (
@@ -47,6 +51,11 @@ const Comments = ({ commentsLoading, addComment, getComments, comments }) => {
                                 <Avatar aria-label="learning-day" className={classes.avatar}>
                                     {comment.userId}
                                 </Avatar>
+                            }
+                            action={user.id === comment.userId ?
+                                <IconButton aria-label="settings" onClick={(e) => handleDeleteCommentClick(e, comment.id)}>
+                                    <DeleteIcon />
+                                </IconButton> : ''
                             }
                             title={comment.userId}
                             subheader={new Date(comment.date).toDateString()}

--- a/src/components/LearningDaysList/LearningDay/Comments/Comments.js
+++ b/src/components/LearningDaysList/LearningDay/Comments/Comments.js
@@ -27,6 +27,7 @@ const Comments = ({ commentsLoading, addComment, getComments, deleteComment, com
 
     const handleAddCommentClick = (e) => {
         addComment(comment);
+        setComment('');
     }
 
     const handleDeleteCommentClick = (e, commentId) => {

--- a/src/components/LearningDaysList/LearningDay/Comments/Comments.styles.js
+++ b/src/components/LearningDaysList/LearningDay/Comments/Comments.styles.js
@@ -27,7 +27,8 @@ export const useStyles = makeStyles((theme) => ({
         backgroundColor: red[500],
     },
     card: {
-        marginBottom: theme.spacing(1)
+        marginBottom: theme.spacing(1),
+        marginLeft: theme.spacing(1)
     },
     paper: {
         padding: theme.spacing(2),

--- a/src/components/LearningDaysList/LearningDay/Comments/Comments.styles.js
+++ b/src/components/LearningDaysList/LearningDay/Comments/Comments.styles.js
@@ -1,0 +1,30 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useStyles = makeStyles((theme) => ({
+    root: {
+        flexGrow: 1,
+    },
+    container: {
+        height: '100%'
+    },
+    commentField: {
+        width: '100%'
+    },
+    commentFieldGrid: {
+        height: '100px'
+    },
+    commentButton: {
+        position: 'absolute',
+        bottom: theme.spacing(9),
+        right: theme.spacing(3)
+    },
+    commentsList: {
+        overflowY: 'scroll',
+        maxHeight: '100%'
+    },
+    paper: {
+        padding: theme.spacing(2),
+        width: '90%',
+        margin: theme.spacing(1)
+    }
+}));

--- a/src/components/LearningDaysList/LearningDay/Comments/Comments.styles.js
+++ b/src/components/LearningDaysList/LearningDay/Comments/Comments.styles.js
@@ -1,4 +1,5 @@
 import { makeStyles } from '@material-ui/core/styles';
+import { red } from '@material-ui/core/colors';
 
 export const useStyles = makeStyles((theme) => ({
     root: {
@@ -21,6 +22,12 @@ export const useStyles = makeStyles((theme) => ({
     commentsList: {
         overflowY: 'scroll',
         maxHeight: '100%'
+    },
+    avatar: {
+        backgroundColor: red[500],
+    },
+    card: {
+        marginBottom: theme.spacing(1)
     },
     paper: {
         padding: theme.spacing(2),

--- a/src/components/LearningDaysList/LearningDay/LearningDay.js
+++ b/src/components/LearningDaysList/LearningDay/LearningDay.js
@@ -97,7 +97,6 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
             })
             .then(res => {
                 getComments();
-                console.log(res);
             })
             .catch(err => {
                 setAlert({ open: true, message: err.response.data.message, severity: 'error' });
@@ -111,7 +110,6 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
             .delete(`${process.env.REACT_APP_SERVER_URL}/api/comment/${commentId}/delete`)
             .then(res => {
                 getComments();
-                console.log(res);
             })
             .catch(err => {
                 setAlert({ open: true, message: err.response.data.message, severity: 'error' });
@@ -125,10 +123,8 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
         axios
             .get(`${process.env.REACT_APP_SERVER_URL}/api/comment/list`)
             .then(res => {
-                console.log(res.data);
                 setComments(res.data);
                 setCommentsLoading(false);
-                console.log(res);
             })
             .catch(err => {
                 setAlert({ open: true, message: err.response.data.message, severity: 'error' });

--- a/src/components/LearningDaysList/LearningDay/LearningDay.js
+++ b/src/components/LearningDaysList/LearningDay/LearningDay.js
@@ -162,7 +162,7 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
                 </DialogTitle>
                 <DialogContent>
                     <Grid container spacing={1} direction="row" className={classes.container}>
-                        <Grid item xs={9} id="contents">
+                        <Grid item xs={8} id="contents">
                             <Grid container spacing={10} direction="column" justify="space-around">
                                 <Grid item xs={12}>
                                     <MuiPickersUtilsProvider utils={DateFnsUtils}>
@@ -250,7 +250,7 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
                                 </Grid>
                             </Grid>
                         </Grid>
-                        <Grid item xs={3} id="comments">
+                        <Grid item xs={4} id="comments">
                             {learningDayNew ? '' : <Comments commentsLoading={commentsLoading} setCommentsLoading={setCommentsLoading} addComment={addComment} deleteComment={deleteComment} getComments={getComments} comments={comments} />}
                         </Grid>
                     </Grid>

--- a/src/components/LearningDaysList/LearningDay/LearningDay.js
+++ b/src/components/LearningDaysList/LearningDay/LearningDay.js
@@ -37,6 +37,7 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
     const [subtopicsOpen, setSubtopicsOpen] = useState(false);
     const [deleteDialog, setDeleteDialog] = useState(false);
     const [commentsLoading, setCommentsLoading] = useState(false);
+    const [comments, setComments] = useState([]);
     const classes = useStyles();
 
     useEffect(() => {
@@ -99,6 +100,22 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
                 userId: user.id
             })
             .then(res => {
+                getComments();
+                console.log(res);
+            })
+            .catch(err => {
+                setAlert({ open: true, message: err.response.data.message, severity: 'error' });
+                setCommentsLoading(false);
+            });
+    }
+
+    const getComments = () => {
+        setCommentsLoading(true);
+        axios
+            .get(`${process.env.REACT_APP_SERVER_URL}/api/comment/list`)
+            .then(res => {
+                console.log(res.data);
+                setComments(res.data);
                 setCommentsLoading(false);
                 console.log(res);
             })
@@ -219,7 +236,7 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
                             </Grid>
                         </Grid>
                         <Grid item xs={3} id="comments">
-                            <Comments commentsLoading={commentsLoading} setCommentsLoading={setCommentsLoading} addComment={addComment} />
+                            {learningDayNew ? '' : <Comments commentsLoading={commentsLoading} setCommentsLoading={setCommentsLoading} addComment={addComment} getComments={getComments} comments={comments} />}
                         </Grid>
                     </Grid>
                 </DialogContent>

--- a/src/components/LearningDaysList/LearningDay/LearningDay.js
+++ b/src/components/LearningDaysList/LearningDay/LearningDay.js
@@ -33,6 +33,7 @@ const LearningDay = ({ setLearningDayModal, learningDayEditable, learningDayNew,
     const [subtopics, setSubtopics] = useState([]);
     const [topicsOpen, setTopicsOpen] = useState(false);
     const [subtopicsOpen, setSubtopicsOpen] = useState(false);
+    const [deleteDialog, setDeleteDialog] = useState(false);
     const classes = useStyles();
 
     useEffect(() => {
@@ -82,143 +83,162 @@ const LearningDay = ({ setLearningDayModal, learningDayEditable, learningDayNew,
     }
 
     const handleDeleteLearningDay = (e) => {
+        setDeleteDialog(false);
         deleteLearningDay(learningDay.id);
     }
 
     return (
-        <Dialog fullWidth="lg" maxWidth="lg" onClose={(e) => handleLearningDayClose(e)} open={(e) => handleLearningDayClose(e)} classes={{ paper: classes.LearningDayModal }}>
-            <DialogTitle className={classes.dialogTitle}>
-                <TextField
-                    className={classes.title}
-                    required
-                    placeholder="Title"
-                    value={title}
-                    onChange={e => setTitle(e.target.value)}
-                    InputProps={{
-                        readOnly: !learningDayEditable,
-                        classes: { input: classes.title }
-                    }}
-                    size="medium"
-                />
-                <IconButton aria-label="close" className={classes.closeButton} onClick={(e) => handleLearningDayClose(e)}>
-                    <CloseIcon />
-                </IconButton>
-            </DialogTitle>
-            <DialogContent>
-                <Grid container spacing={1} direction="row">
-                    <Grid item xs={9} id="contents">
-                        <Grid container spacing={10} direction="column" justify="space-around">
-                            <Grid item xs={12}>
-                                <MuiPickersUtilsProvider utils={DateFnsUtils}>
-                                    <KeyboardDatePicker
-                                        fullWidth
-                                        disableToolbar
-                                        variant="inline"
-                                        format="yyyy-MM-dd"
-                                        margin="normal"
-                                        label="Date"
-                                        readOnly={learningDayEditable}
-                                        value={date}
-                                        onChange={(date) => setDate(date)}
-                                        KeyboardButtonProps={{
-                                            'aria-label': 'change date',
-                                        }}
-                                    />
-                                </MuiPickersUtilsProvider>
-                            </Grid>
-                            <Grid item xs={12}>
-                                <FormControl className={classes.formControl} fullWidth>
-                                    <InputLabel id="demo-mutiple-chip-label">Topics</InputLabel>
-                                    <Select
-                                        labelId="demo-mutiple-chip-label"
-                                        id="demo-mutiple-chip"
-                                        multiple
-                                        value={topics}
-                                        onChange={(e) => handleTopicsChange(e)}
-                                        open={topicsOpen}
-                                        onOpen={(e) => learningDayEditable ? setTopicsOpen(true) : setTopicsOpen(false)}
-                                        onClose={(e) => setTopicsOpen(false)}
-                                        input={<Input id="select-multiple-chip" />}
-                                        renderValue={(selected) => (
-                                            <div className={classes.chips}>
-                                                {selected.map((topic) => (
-                                                    <Tooltip title={topic.description} arrow>
-                                                        <Chip color="primary" key={topic.id} label={topic.title} className={classes.topicChip} />
-                                                    </Tooltip>
-                                                ))}
-                                            </div>
-                                        )}
-                                    >
-                                        {allTopics.map((topic) => (
-                                            !topic.parentId ?
-                                                <MenuItem key={topic.id} value={topic}>
-                                                    {topic.title}
-                                                </MenuItem> : ''
-                                        ))}
-                                    </Select>
-                                </FormControl>
-                            </Grid>
-                            <Grid item xs={12}>
-                                <FormControl className={classes.formControl} fullWidth>
-                                    <InputLabel id="demo-mutiple-chip-label">Subtopics</InputLabel>
-                                    <Select
-                                        labelId="demo-mutiple-chip-label"
-                                        id="demo-mutiple-chip"
-                                        multiple
-                                        value={subtopics}
-                                        onChange={(e) => handleSubtopicsChange(e)}
-                                        open={subtopicsOpen}
-                                        onOpen={(e) => learningDayEditable ? setSubtopicsOpen(true) : setSubtopicsOpen(false)}
-                                        onClose={(e) => setSubtopicsOpen(false)}
-                                        input={<Input id="select-multiple-chip" />}
-                                        renderValue={(selected) => (
-                                            <div className={classes.chips}>
-                                                {selected.map((topic) => (
-                                                    <Tooltip title={topic.description} arrow>
-                                                        <Chip color="primary" key={topic.id} label={topic.title} className={classes.topicChip} />
-                                                    </Tooltip>
-                                                ))}
-                                            </div>
-                                        )}
-                                    >
-                                        {topics.map((masterTopic) => (
-                                            allTopics.map((topic) => (
-                                                topic.parentId === masterTopic.id ?
+        <div>
+            <Dialog fullWidth="lg" maxWidth="lg" onClose={(e) => handleLearningDayClose(e)} open={(e) => handleLearningDayClose(e)} classes={{ paper: classes.LearningDayModal }}>
+                <DialogTitle className={classes.dialogTitle}>
+                    <TextField
+                        className={classes.title}
+                        required
+                        placeholder="Title"
+                        value={title}
+                        onChange={e => setTitle(e.target.value)}
+                        InputProps={{
+                            readOnly: !learningDayEditable,
+                            classes: { input: classes.title }
+                        }}
+                        size="medium"
+                    />
+                    <IconButton aria-label="close" className={classes.closeButton} onClick={(e) => handleLearningDayClose(e)}>
+                        <CloseIcon />
+                    </IconButton>
+                </DialogTitle>
+                <DialogContent>
+                    <Grid container spacing={1} direction="row">
+                        <Grid item xs={9} id="contents">
+                            <Grid container spacing={10} direction="column" justify="space-around">
+                                <Grid item xs={12}>
+                                    <MuiPickersUtilsProvider utils={DateFnsUtils}>
+                                        <KeyboardDatePicker
+                                            fullWidth
+                                            disableToolbar
+                                            variant="inline"
+                                            format="yyyy-MM-dd"
+                                            margin="normal"
+                                            label="Date"
+                                            readOnly={learningDayEditable}
+                                            value={date}
+                                            onChange={(date) => setDate(date)}
+                                            KeyboardButtonProps={{
+                                                'aria-label': 'change date',
+                                            }}
+                                        />
+                                    </MuiPickersUtilsProvider>
+                                </Grid>
+                                <Grid item xs={12}>
+                                    <FormControl className={classes.formControl} fullWidth>
+                                        <InputLabel id="demo-mutiple-chip-label">Topics</InputLabel>
+                                        <Select
+                                            labelId="demo-mutiple-chip-label"
+                                            id="demo-mutiple-chip"
+                                            multiple
+                                            value={topics}
+                                            onChange={(e) => handleTopicsChange(e)}
+                                            open={topicsOpen}
+                                            onOpen={(e) => learningDayEditable ? setTopicsOpen(true) : setTopicsOpen(false)}
+                                            onClose={(e) => setTopicsOpen(false)}
+                                            input={<Input id="select-multiple-chip" />}
+                                            renderValue={(selected) => (
+                                                <div className={classes.chips}>
+                                                    {selected.map((topic) => (
+                                                        <Tooltip title={topic.description} arrow>
+                                                            <Chip color="primary" key={topic.id} label={topic.title} className={classes.topicChip} />
+                                                        </Tooltip>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        >
+                                            {allTopics.map((topic) => (
+                                                !topic.parentId ?
                                                     <MenuItem key={topic.id} value={topic}>
-                                                        <Chip color="primary" label={masterTopic.title} className={classes.topicChip} /> {topic.title}
+                                                        {topic.title}
                                                     </MenuItem> : ''
-                                            ))
-                                        ))}
-                                    </Select>
-                                </FormControl>
+                                            ))}
+                                        </Select>
+                                    </FormControl>
+                                </Grid>
+                                <Grid item xs={12}>
+                                    <FormControl className={classes.formControl} fullWidth>
+                                        <InputLabel id="demo-mutiple-chip-label">Subtopics</InputLabel>
+                                        <Select
+                                            labelId="demo-mutiple-chip-label"
+                                            id="demo-mutiple-chip"
+                                            multiple
+                                            value={subtopics}
+                                            onChange={(e) => handleSubtopicsChange(e)}
+                                            open={subtopicsOpen}
+                                            onOpen={(e) => learningDayEditable ? setSubtopicsOpen(true) : setSubtopicsOpen(false)}
+                                            onClose={(e) => setSubtopicsOpen(false)}
+                                            input={<Input id="select-multiple-chip" />}
+                                            renderValue={(selected) => (
+                                                <div className={classes.chips}>
+                                                    {selected.map((topic) => (
+                                                        <Tooltip title={topic.description} arrow>
+                                                            <Chip color="primary" key={topic.id} label={topic.title} className={classes.topicChip} />
+                                                        </Tooltip>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        >
+                                            {topics.map((masterTopic) => (
+                                                allTopics.map((topic) => (
+                                                    topic.parentId === masterTopic.id ?
+                                                        <MenuItem key={topic.id} value={topic}>
+                                                            <Chip color="primary" label={masterTopic.title} className={classes.topicChip} /> {topic.title}
+                                                        </MenuItem> : ''
+                                                ))
+                                            ))}
+                                        </Select>
+                                    </FormControl>
+                                </Grid>
                             </Grid>
                         </Grid>
-                    </Grid>
-                    <Grid item xs={3} id="comments">
+                        <Grid item xs={3} id="comments">
 
+                        </Grid>
                     </Grid>
-                </Grid>
-            </DialogContent>
-            <DialogActions>
-                {!learningDayNew && !learningDayEditable ?
-                    <Button autoFocus variant="contained" color="primary" onClick={(e) => handleDeleteLearningDay(e)}>
-                        Delete
+                </DialogContent>
+                <DialogActions>
+                    {!learningDayNew && !learningDayEditable ?
+                        <Button autoFocus variant="contained" color="primary" onClick={(e) => setDeleteDialog(true)}>
+                            Delete
                     </Button> : ''
-                }
-                {learningDayNew ?
-                    <Button autoFocus variant="contained" color="primary" onClick={(e) => handleCreateLearningDay(e)}>
-                        Create Learning Day
+                    }
+                    {learningDayNew ?
+                        <Button autoFocus variant="contained" color="primary" onClick={(e) => handleCreateLearningDay(e)}>
+                            Create Learning Day
                     </Button> :
-                    learningDayEditable ?
-                        <Button autoFocus variant="contained" color="primary" onClick={(e) => handleSaveLearningDay(e)}>
-                            Save
+                        learningDayEditable ?
+                            <Button autoFocus variant="contained" color="primary" onClick={(e) => handleSaveLearningDay(e)}>
+                                Save
                         </Button> :
-                        <Button autoFocus variant="contained" color="primary" onClick={(e) => setLearningDayEditable(true)}>
-                            Edit
+                            <Button autoFocus variant="contained" color="primary" onClick={(e) => setLearningDayEditable(true)}>
+                                Edit
                         </Button>
-                }
-            </DialogActions>
-        </Dialog>
+                    }
+                </DialogActions>
+            </Dialog>
+            <Dialog
+                open={deleteDialog}
+                onClose={(e) => setDeleteDialog(false)}
+                aria-labelledby="alert-dialog-title"
+                aria-describedby="alert-dialog-description"
+            >
+                <DialogTitle id="alert-dialog-title">{"Are you sure you want to delete this Learning Day?"}</DialogTitle>
+                <DialogActions>
+                    <Button onClick={(e) => handleDeleteLearningDay(e)} color="primary">
+                        Yes
+                </Button>
+                    <Button onClick={(e) => setDeleteDialog(false)} color="primary" autoFocus>
+                        No
+                </Button>
+                </DialogActions>
+            </Dialog>
+        </div>
     );
 }
 

--- a/src/components/LearningDaysList/LearningDay/LearningDay.js
+++ b/src/components/LearningDaysList/LearningDay/LearningDay.js
@@ -55,11 +55,7 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
 
     const handleTopicsChange = (e) => {
         if (learningDayEditable) {
-            const newTopics = e.target.value;
-            setTopics(newTopics);
-            setSubtopics(subtopics.filter((subtopic) => {
-                return newTopics.some(topic => topic.id === subtopic.parentId);
-            }))
+            setTopics(e.target.value);
         }
     };
 
@@ -231,13 +227,13 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
                                                 <div className={classes.chips}>
                                                     {selected.map((topic) => (
                                                         <Tooltip title={topic.description} arrow>
-                                                            <Chip color="primary" key={topic.id} label={topic.title} className={classes.topicChip} />
+                                                            <Chip color="primary" key={topic.id} label={topic.title} className={classes.topicChip} variant={"outlined"}/>
                                                         </Tooltip>
                                                     ))}
                                                 </div>
                                             )}
                                         >
-                                            {topics.map((masterTopic) => (
+                                            {allTopics.filter(topic => !topic.parentId).map((masterTopic) => (
                                                 allTopics.map((topic) => (
                                                     topic.parentId === masterTopic.id ?
                                                         <MenuItem key={topic.id} value={topic}>

--- a/src/components/LearningDaysList/LearningDay/LearningDay.js
+++ b/src/components/LearningDaysList/LearningDay/LearningDay.js
@@ -16,16 +16,18 @@ import FormControl from '@material-ui/core/FormControl';
 import Select from '@material-ui/core/Select';
 import Chip from '@material-ui/core/Chip';
 import Tooltip from '@material-ui/core/Tooltip';
+import axios from 'axios';
 import {
     MuiPickersUtilsProvider,
     KeyboardDatePicker,
 } from '@material-ui/pickers';
 import DateFnsUtils from '@date-io/date-fns';
 
+import Comments from '../LearningDay/Comments/Comments';
 
 import { useStyles } from './LearningDay.styles';
 
-const LearningDay = ({ setLearningDayModal, learningDayEditable, learningDayNew, createLearningDay, updateLearningDay, deleteLearningDay, setLearningDayEditable, allTopics, learningDay }) => {
+const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learningDayNew, createLearningDay, updateLearningDay, deleteLearningDay, setLearningDayEditable, allTopics, learningDay }) => {
     const [user] = useContext(UserContext);
     const [title, setTitle] = useState('');
     const [date, setDate] = useState(new Date());
@@ -34,6 +36,7 @@ const LearningDay = ({ setLearningDayModal, learningDayEditable, learningDayNew,
     const [topicsOpen, setTopicsOpen] = useState(false);
     const [subtopicsOpen, setSubtopicsOpen] = useState(false);
     const [deleteDialog, setDeleteDialog] = useState(false);
+    const [commentsLoading, setCommentsLoading] = useState(false);
     const classes = useStyles();
 
     useEffect(() => {
@@ -87,6 +90,24 @@ const LearningDay = ({ setLearningDayModal, learningDayEditable, learningDayNew,
         deleteLearningDay(learningDay.id);
     }
 
+    const addComment = (comment) => {
+        setCommentsLoading(true);
+        axios
+            .post(`${process.env.REACT_APP_SERVER_URL}/api/comment/add`, {
+                comment: comment,
+                learningDayId: learningDay.id,
+                userId: user.id
+            })
+            .then(res => {
+                setCommentsLoading(false);
+                console.log(res);
+            })
+            .catch(err => {
+                setAlert({ open: true, message: err.response.data.message, severity: 'error' });
+                setCommentsLoading(false);
+            });
+    }
+
     return (
         <div>
             <Dialog fullWidth="lg" maxWidth="lg" onClose={(e) => handleLearningDayClose(e)} open={(e) => handleLearningDayClose(e)} classes={{ paper: classes.LearningDayModal }}>
@@ -108,7 +129,7 @@ const LearningDay = ({ setLearningDayModal, learningDayEditable, learningDayNew,
                     </IconButton>
                 </DialogTitle>
                 <DialogContent>
-                    <Grid container spacing={1} direction="row">
+                    <Grid container spacing={1} direction="row" className={classes.container}>
                         <Grid item xs={9} id="contents">
                             <Grid container spacing={10} direction="column" justify="space-around">
                                 <Grid item xs={12}>
@@ -198,7 +219,7 @@ const LearningDay = ({ setLearningDayModal, learningDayEditable, learningDayNew,
                             </Grid>
                         </Grid>
                         <Grid item xs={3} id="comments">
-
+                            <Comments commentsLoading={commentsLoading} setCommentsLoading={setCommentsLoading} addComment={addComment} />
                         </Grid>
                     </Grid>
                 </DialogContent>

--- a/src/components/LearningDaysList/LearningDay/LearningDay.js
+++ b/src/components/LearningDaysList/LearningDay/LearningDay.js
@@ -109,6 +109,21 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
             });
     }
 
+    const deleteComment = (commentId) => {
+        setCommentsLoading(true);
+        axios
+            .delete(`${process.env.REACT_APP_SERVER_URL}/api/comment/${commentId}/delete`)
+            .then(res => {
+                getComments();
+                console.log(res);
+            })
+            .catch(err => {
+                setAlert({ open: true, message: err.response.data.message, severity: 'error' });
+                setCommentsLoading(false);
+            });
+    }
+
+    // backend should be updated to provide /api/comment/{learning-day-id}/list instead of this
     const getComments = () => {
         setCommentsLoading(true);
         axios
@@ -236,7 +251,7 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
                             </Grid>
                         </Grid>
                         <Grid item xs={3} id="comments">
-                            {learningDayNew ? '' : <Comments commentsLoading={commentsLoading} setCommentsLoading={setCommentsLoading} addComment={addComment} getComments={getComments} comments={comments} />}
+                            {learningDayNew ? '' : <Comments commentsLoading={commentsLoading} setCommentsLoading={setCommentsLoading} addComment={addComment} deleteComment={deleteComment} getComments={getComments} comments={comments} />}
                         </Grid>
                     </Grid>
                 </DialogContent>

--- a/src/components/LearningDaysList/LearningDay/LearningDay.js
+++ b/src/components/LearningDaysList/LearningDay/LearningDay.js
@@ -169,7 +169,7 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
                                             format="yyyy-MM-dd"
                                             margin="normal"
                                             label="Date"
-                                            readOnly={learningDayEditable}
+                                            readOnly={!learningDayEditable}
                                             value={date}
                                             onChange={(date) => setDate(date)}
                                             KeyboardButtonProps={{
@@ -258,11 +258,11 @@ const LearningDay = ({ setAlert, setLearningDayModal, learningDayEditable, learn
                     </Button> : ''
                     }
                     {learningDayNew ?
-                        <Button autoFocus variant="contained" color="primary" onClick={(e) => handleCreateLearningDay(e)}>
+                    <Button disabled={!title || !(topics.length || subtopics.length || !date)} autoFocus variant="contained" color="primary" onClick={(e) => handleCreateLearningDay(e)}>
                             Create Learning Day
                     </Button> :
                         learningDayEditable ?
-                            <Button autoFocus variant="contained" color="primary" onClick={(e) => handleSaveLearningDay(e)}>
+                            <Button disabled={!title || !(topics.length || subtopics.length || !date)} autoFocus variant="contained" color="primary" onClick={(e) => handleSaveLearningDay(e)}>
                                 Save
                         </Button> :
                             <Button autoFocus variant="contained" color="primary" onClick={(e) => setLearningDayEditable(true)}>

--- a/src/components/LearningDaysList/LearningDay/LearningDay.styles.js
+++ b/src/components/LearningDaysList/LearningDay/LearningDay.styles.js
@@ -4,6 +4,9 @@ export const useStyles = makeStyles((theme) => ({
     LearningDayModal: {
         height: '80%'
     },
+    container: {
+        height: '100%'
+    },
     closeButton: {
         position: 'absolute',
         right: theme.spacing(1),

--- a/src/components/LearningDaysList/LearningDayCard/LearningDayCard.js
+++ b/src/components/LearningDaysList/LearningDayCard/LearningDayCard.js
@@ -38,7 +38,7 @@ const LearningDayCard = ({ learningDay, handleLearningDayClick }) => {
                 <CardContent>
                     {learningDay.topics.map(topic =>
                         <Tooltip title={topic.description} arrow>
-                            <Chip color="primary" className={classes.topicChip} key={topic.id} label={topic.title}></Chip>
+                            <Chip color="primary" className={classes.topicChip} key={topic.id} label={topic.title} variant={topic.parentId ? 'outlined' : 'default'}></Chip>
                         </Tooltip>
                     )}
                 </CardContent>

--- a/src/components/LearningDaysList/LearningDaysList.js
+++ b/src/components/LearningDaysList/LearningDaysList.js
@@ -116,7 +116,7 @@ const LearningDaysList = ({ setLoading, setAlert, topics, isTeamCalendar }) => {
                 </Grid>
                 <Grid item xs={12}>
                     {
-                        learningDays.map(learningDay =>
+                        learningDays.sort((learningDay1, learningDay2) => new Date(learningDay1.date).getTime() > new Date(learningDay2.date).getTime() ? -1 : 1).map(learningDay =>
                             <LearningDayCard key={learningDay.id} learningDay={learningDay} handleLearningDayClick={handleLearningDayClick} />
                         )
                     }

--- a/src/components/LearningDaysList/LearningDaysList.js
+++ b/src/components/LearningDaysList/LearningDaysList.js
@@ -104,7 +104,7 @@ const LearningDaysList = ({ setLoading, setAlert, topics, isTeamCalendar }) => {
 
     return (
         <div>
-            {learningDayModal ? <LearningDay setLearningDayModal={setLearningDayModal} learningDayNew={learningDayNew} learningDayEditable={learningDayEditable} setLearningDayEditable={setLearningDayEditable} deleteLearningDay={deleteLearningDay} updateLearningDay={updateLearningDay} createLearningDay={createLearningDay} allTopics={topics} learningDay={selectedLearningDay} /> : ''}
+            {learningDayModal ? <LearningDay setAlert={setAlert} setLearningDayModal={setLearningDayModal} learningDayNew={learningDayNew} learningDayEditable={learningDayEditable} setLearningDayEditable={setLearningDayEditable} deleteLearningDay={deleteLearningDay} updateLearningDay={updateLearningDay} createLearningDay={createLearningDay} allTopics={topics} learningDay={selectedLearningDay} /> : ''}
             <Grid container spacing={3} direction="row" justify="space-evenly">
                 <Grid item xs={6}>
                     <Typography variant="h4">


### PR DESCRIPTION
What was done:
- Comments functionality added
- Unlocked ability to have a learning day with subtopics only (changed the way subtopics look too)
- Added a confirmation dialog when deleting a learning day
- Added sorting for Learning Days and Goals by date
- Added input validation when creating or editing a learning day

What's left to do:
- z-index of loading context (did not manage to figure out how to fix it)
- backend should add an endpoint to retrieve the comments only for the particular learning day (for now we retrieve all the comments of all the learning days)
- for now, comments only display user id, backend should include first and last names of the user in the response