### PR TITLE
Fix user edit in team management page

### DIFF
--- a/src/components/UserEditDialog/UserEditDialog.js
+++ b/src/components/UserEditDialog/UserEditDialog.js
@@ -11,12 +11,30 @@ import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 
 const UserEditDialog = ({open, setOpen, user, getUsers, setAlert}) => {
+  const [allUsers, setAllUsers] = useState([]);
   const [currentUser, setCurrentUser] = useState({});
   const [setLoading] = useContext(LoadingContext);
 
   useEffect(() => {
     setCurrentUser(user);
+    getAllUsers();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user])
+
+  const getAllUsers = () => {
+    setLoading(true);
+    axios
+        .get(`${process.env.REACT_APP_SERVER_URL}/api/user/list`)
+        .then(res => {
+          console.log(res.data)
+          setAllUsers(res.data);
+          setLoading(false);
+        })
+        .catch(err => {
+          setLoading(false);
+          setAlert({ open: true, message: err.response.data.message, severity: 'error' });
+        });
+  };
 
   function changeLimit(e) {
     let editUser = {...currentUser};
@@ -28,7 +46,7 @@ const UserEditDialog = ({open, setOpen, user, getUsers, setAlert}) => {
     setLoading(true);
     setOpen(false);
     axios
-        .put(`${process.env.REACT_APP_SERVER_URL}/api/user/${currentUser.id}/update-restriction-days?restrictionDays=${currentUser.restrictionDays}`)
+        .put(`${process.env.REACT_APP_SERVER_URL}/api/user/${currentUser.id}/update-for-leader`, {restrictionDays: currentUser.restrictionDays, managerId: currentUser.managerId})
         .then(res => {
           getUsers();
           setLoading(false);
@@ -39,9 +57,9 @@ const UserEditDialog = ({open, setOpen, user, getUsers, setAlert}) => {
           setAlert({ open: true, message: err.response.data.message, severity: 'error' });
         });
   };
-
   return (
-    <Dialog open={open} onClose={() => setOpen(false)} fullWidth={true}>
+    <div>
+      <Dialog open={open} onClose={() => setOpen(false)} fullWidth={true}>
         <DialogTitle>Change learning days limit</DialogTitle>
         <DialogContent>
             <TextField
@@ -61,7 +79,9 @@ const UserEditDialog = ({open, setOpen, user, getUsers, setAlert}) => {
                 Update
         </Button>
         </DialogActions>
-    </Dialog>
+      </Dialog>
+    </div>
+    
   );
 }
 

--- a/src/components/UserEditDialog/UserEditDialog.js
+++ b/src/components/UserEditDialog/UserEditDialog.js
@@ -9,11 +9,18 @@ import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
+import InputLabel from '@material-ui/core/InputLabel';
+import FormControl from '@material-ui/core/FormControl';
+import Select from '@material-ui/core/Select';
+import MenuItem from '@material-ui/core/MenuItem';
+
+import { useStyles } from './UserEditDialog.styles';
 
 const UserEditDialog = ({open, setOpen, user, getUsers, setAlert}) => {
   const [allUsers, setAllUsers] = useState([]);
   const [currentUser, setCurrentUser] = useState({});
   const [setLoading] = useContext(LoadingContext);
+  const classes = useStyles();
 
   useEffect(() => {
     setCurrentUser(user);
@@ -26,7 +33,6 @@ const UserEditDialog = ({open, setOpen, user, getUsers, setAlert}) => {
     axios
         .get(`${process.env.REACT_APP_SERVER_URL}/api/user/list`)
         .then(res => {
-          console.log(res.data)
           setAllUsers(res.data);
           setLoading(false);
         })
@@ -36,9 +42,15 @@ const UserEditDialog = ({open, setOpen, user, getUsers, setAlert}) => {
         });
   };
 
-  function changeLimit(e) {
+  const changeLimit = (e) => {
     let editUser = {...currentUser};
     editUser.restrictionDays = e.target.value;
+    setCurrentUser(editUser);
+  }
+
+  const changeManager = (e) => {
+    let editUser = {...currentUser};
+    editUser.managerId = e.target.value;
     setCurrentUser(editUser);
   }
 
@@ -71,6 +83,17 @@ const UserEditDialog = ({open, setOpen, user, getUsers, setAlert}) => {
                 onChange={(e) => changeLimit(e)}
             />
         </DialogContent>
+        <DialogTitle>Change manager</DialogTitle>
+            <DialogContent>
+                <FormControl className={classes.fullWidth}>
+                    <InputLabel>Users</InputLabel>
+                    <Select onChange={(e) => changeManager(e)} value={currentUser.managerId}>
+                      {allUsers.filter(user => user.id !== currentUser.id).map(user => {
+                        return <MenuItem key={user.id} value={user.id}>{user.email}</MenuItem>
+                      })}
+                    </Select>
+                </FormControl>
+            </DialogContent>
         <DialogActions>
             <Button onClick={() => setOpen(false)} color="primary">
                 Cancel

--- a/src/components/UserEditDialog/UserEditDialog.styles.js
+++ b/src/components/UserEditDialog/UserEditDialog.styles.js
@@ -1,0 +1,7 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const useStyles = makeStyles(theme => ({
+    fullWidth: {
+      width: '100%'
+    }
+}));

--- a/src/index.scss
+++ b/src/index.scss
@@ -11,3 +11,11 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.MuiDialog-root {
+  z-index: auto !important;
+}
+
+header {
+  z-index: 0 !important;
+}


### PR DESCRIPTION
1. Fix z-index for loading.
2. Add user manager change in edit modal.

Right now if you open edit modal you will not see your manager selected by default, because we don't get it from backend, but there is task created for that, and in the code its already implemented.